### PR TITLE
Downgrade jeet to 6.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-uglify": "^1.0.2"
   },
   "dependencies": {
-    "jeet": "^6.1.4",
+    "jeet": "=6.1.2",
     "kouto-swiss": "^0.11.14",
     "rupture": "^0.6.1"
   }


### PR DESCRIPTION
Hi.

I tried cads-jekyll-template, but I get error.

```bash
$ git clone git@github.com:willianjusten/cards-jekyll-template
$ cd <cards-jekyll-template directory>
$ npm install
$ gulp
...
[15:17:58] Plumber found unhandled error:
 Error in plugin 'gulp-stylus'
Message:
    /Users/pinzolo/develop/github.com/pinzolo/cards-jekyll-template/src/styl/main.styl:22:9
   18|     And of course, look in node_modules for axis-css and jeet
   19| */
   20|
   21| @import "kouto-swiss"
   22| @import "jeet"
---------------^
   23| normalize()
   24| @import "_variables"
   25| @import "_typo"

failed to locate @import file jeet.styl

Details:
    lineno: 22
    column: 9
    filename: /Users/pinzolo/develop/github.com/pinzolo/cards-jekyll-template/src/styl/main.styl
    stylusStack:
    input: /*  Syntax Quick Reference for Jeet
    --------------------------
    column(ratios = 1, offset = 0, cycle = 0, uncycle = 0, gutter = jeet.gutter)
    span(ratio = 1, offset = 0)
    shift(ratios = 0, col_or_span = column, gutter = jeet.gutter)
    unshift()
    edit()
    center(max_width = 1410px, pad = 0)
    stack(pad = 0, align = false)
    unstack()
    align(direction = both)
    cf()

    For more info see:
        Kouto Swiss Doc: http://kouto-swiss.io/
        Jeet Doc: http://jeet.gs

    And of course, look in node_modules for axis-css and jeet
*/

@import "kouto-swiss"
@import "jeet"
normalize()

...
```

jeet (> 6.1.2) is broken.
https://github.com/mojotech/jeet/issues/487

Perhaps, Your issues #12 #10 are raised by this.
I think we should use jeet 6.1.2 until jeet will be fixed.
In my box, using jeet 6.1.2 this template works good.