### PR TITLE
Desabilitar comentários nos posts com comments: false.

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,7 +12,9 @@
 
             {% include share.html %}
             {% include author.html %}
-            {% include comments.html %}
+            {% if page.comments != false %} 
+                {% include comments.html %}
+            {% endif %}
             {% include footer.html %}
         </section>
     </body>

--- a/initpost.sh
+++ b/initpost.sh
@@ -111,6 +111,7 @@ initpost_content() {
 
 echo "---"
 echo "layout: post"
+echo "comments: true"
 echo "title: \"${POST_TITLE}\""
 echo "date: ${CURRENT_DATE} ${TIME}"
 echo "image: '/assets/img/'"


### PR DESCRIPTION
Esta alteração **não afeta posts já publicados**, logo que se não houver a variável "comments" no front-matter ela será considerada undefined então os comentários serão habilitados.
Para realmente desabilitar os comentários é necessário configurar
`comments: false` no post