### PR TITLE
Update Readme.md about Running the blog in local

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -108,6 +108,14 @@ In order to compile the assets and run Jekyll on local you need to follow those 
 - Run `npm install -g gulp gulp-cli`
 - Run `gulp`
 
+If the builded site isn't correctly styled:
+
+- Try temporarily comment out the following line in `_config.yml`.
+   ```
+   # baseurl: "/cards-jekyll-template" # the subpath of your site, e.g. /blog
+   ```
+- Run `gulp` again.
+
 ## Questions
 
 Having a problem getting something to work or want to know why I setup something in a certain way? Ping me on Twitter [@willian_justen](https://twitter.com/willian_justen) or file a [GitHub Issue](https://github.com/willianjusten/will-jekyll-template/issues/new).


### PR DESCRIPTION
When I follow the steps to run the blog in local on Windows 10, I encountered the problem that `gulp` doesn't know that the site have `base_url`, causing scripts and links cannot be correctly linked.

The 2 files that cannot be correctly included.
- `/assets/css/main.css`
   In `_includes\head.html`
   ```html
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
   ```
- `/assets/js/main.js`
   In `_includes\footer.html`
   ```html
   <script src="{{ "/assets/js/main.js" | prepend: site.baseurl }}"></script>
   ```

The easiest way seems to be temporarily remove the `base_url` inside `_config.yml`.

There may be a way to modify `gulpfile.js` and build the site with url: `http://localhost:3000/cards-jekyll-template/` instead of `http://localhost:3000/`.